### PR TITLE
- Adding new filter for threads

### DIFF
--- a/modules/Forum/Database/migrations/2025_07_18_150220_create_threads_table.php
+++ b/modules/Forum/Database/migrations/2025_07_18_150220_create_threads_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->unsignedInteger('user_id');
             $table->string('title');
             $table->text('body');
+            $table->unsignedBigInteger('replies_count')->default(0);
             $table->timestamps();
         });
     }

--- a/modules/Forum/Domain/Models/Reply.php
+++ b/modules/Forum/Domain/Models/Reply.php
@@ -40,6 +40,17 @@ class Reply extends Model
         'type',
     ];
 
+    protected static function booted(): void
+    {
+        static::created(static function (self $reply): void {
+            $reply->thread->increment('replies_count');
+        });
+
+        static::deleted(static function (self $reply): void {
+            $reply->thread->decrement('replies_count');
+        });
+    }
+
     /**
      * @return ReplyFactory
      */
@@ -54,5 +65,14 @@ class Reply extends Model
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * Summary of thread
+     * @return BelongsTo<Thread, Reply>
+     */
+    public function thread(): BelongsTo
+    {
+        return $this->belongsTo(Thread::class, 'thread_id');
     }
 }

--- a/modules/Forum/Domain/Models/Thread.php
+++ b/modules/Forum/Domain/Models/Thread.php
@@ -22,7 +22,7 @@ class Thread extends Model
     protected static function booted(): void
     {
         static::addGlobalScope('repliesCount', static function ($query) {
-            $query->withCount(['replies', 'favorites']);
+            $query->withCount(['favorites']);
         });
 
         static::deleting(static function (self $thread): void {
@@ -57,6 +57,7 @@ class Thread extends Model
         'title',
         'body',
         'type',
+        'replies_count',
     ];
 
     /**

--- a/modules/Forum/Http/Controllers/ReplyController.php
+++ b/modules/Forum/Http/Controllers/ReplyController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Support\Facades\Auth;
 use Modules\Forum\Application\DTOs\Reply\UserAddReplyInThreadDto;
 use Modules\Forum\Application\UseCases\Reply\DeleteReplyUseCase;
 use Modules\Forum\Application\UseCases\Reply\UpdateReplyUseCase;
@@ -26,32 +27,12 @@ class ReplyController extends Controller implements HasMiddleware
         ];
     }
 
-    public function index()
-    {
-        return view('forum::index');
-    }
-
-    public function create()
-    {
-        return view('forum::create');
-    }
-
     public function store(string $channel, string $threadId, UserAddReplyInThreadRequest $request, UserAddReplyInThreadUseCase $case): RedirectResponse
     {
-        $data = new UserAddReplyInThreadDto($threadId, auth()->id(), $request->validated('body'));
+        $data = new UserAddReplyInThreadDto($threadId, Auth::id(), $request->validated('body'));
 
         $thread = $case->execute($data);
         return redirect()->route('threads.show', ['channel' => $thread->channel->slug, 'id' => $thread->id]);
-    }
-
-    public function show($id)
-    {
-        return view('forum::show');
-    }
-
-    public function edit($id)
-    {
-        return view('forum::edit');
     }
 
     public function update(UpdateReplyRequest $request, string $id, UpdateReplyUseCase $case): RedirectResponse

--- a/modules/Forum/Infrastructure/Filters/Thread/UnansweredFilterStrategy.php
+++ b/modules/Forum/Infrastructure/Filters/Thread/UnansweredFilterStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Modules\Forum\Infrastructure\Filters\Thread;
+
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Builder;
+use Modules\Forum\Domain\Contracts\Thread\FilterStrategyInterface;
+
+class UnansweredFilterStrategy implements FilterStrategyInterface
+{
+    /**
+     * Summary of apply
+     * @param Builder $query
+     * @param Request $request
+     * @return Builder
+     */
+    public function apply(Builder $query, Request $request): Builder
+    {
+        if ($this->canHandle($request)) {
+            $query->where('replies_count', '=', 0);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Summary of canHandle
+     * @param Request $request
+     * @return bool
+     */
+    public function canHandle(Request $request): bool
+    {
+        return $request->exists('unanswered') && $request->boolean('unanswered', true) === true;
+    }
+}

--- a/modules/Forum/Infrastructure/Repositories/Thread/AllThreadsRepository.php
+++ b/modules/Forum/Infrastructure/Repositories/Thread/AllThreadsRepository.php
@@ -13,9 +13,7 @@ readonly class AllThreadsRepository implements AllThreadsRepositoryInterface
 {
     public function __construct(
         private FilterThreadsRepositoryInterface $filterThreadsRepository,
-    )
-    {
-    }
+    ) {}
 
     /**
      * @param Request $request
@@ -25,8 +23,8 @@ readonly class AllThreadsRepository implements AllThreadsRepositoryInterface
     public function handle(Request $request, string|null $channel = null): Collection|LengthAwarePaginator
     {
         $threads = Thread::query()
-            ->withCount('replies')
-            ->latest();
+            ->latest()
+            ->orderBy('id');
 
         if (filled($channel)) {
             $threads->where('channel_id', '=', $channel);

--- a/modules/Forum/Infrastructure/Repositories/Thread/Filters/FilterThreadsRepository.php
+++ b/modules/Forum/Infrastructure/Repositories/Thread/Filters/FilterThreadsRepository.php
@@ -2,13 +2,14 @@
 
 namespace Modules\Forum\Infrastructure\Repositories\Thread\Filters;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Modules\Forum\Domain\Contracts\Thread\FilterStrategyInterface;
 use Modules\Forum\Domain\Models\Thread;
-use Modules\Forum\Domain\Repositories\Thread\Filters\FilterThreadsRepositoryInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Modules\Forum\Domain\Contracts\Thread\FilterStrategyInterface;
 use Modules\Forum\Infrastructure\Filters\Thread\PopularFilterStrategy;
 use Modules\Forum\Infrastructure\Filters\Thread\UsernameFilterStrategy;
+use Modules\Forum\Infrastructure\Filters\Thread\UnansweredFilterStrategy;
+use Modules\Forum\Domain\Repositories\Thread\Filters\FilterThreadsRepositoryInterface;
 
 class FilterThreadsRepository implements FilterThreadsRepositoryInterface
 {
@@ -30,7 +31,7 @@ class FilterThreadsRepository implements FilterThreadsRepositoryInterface
     public function apply(Builder $query, Request $request): Builder
     {
         foreach ($this->filters as $filter) {
-            if($filter->canHandle($request)) {
+            if ($filter->canHandle($request)) {
                 $filter->apply($query, $request);
             }
         }
@@ -41,6 +42,7 @@ class FilterThreadsRepository implements FilterThreadsRepositoryInterface
     {
         $this->setStrategy(new UsernameFilterStrategy());
         $this->setStrategy(new PopularFilterStrategy());
+        $this->setStrategy(new UnansweredFilterStrategy());
     }
 
     /**

--- a/modules/Forum/Tests/Feature/ParticipateInForumTest.php
+++ b/modules/Forum/Tests/Feature/ParticipateInForumTest.php
@@ -2,10 +2,8 @@
 
 namespace Modules\Forum\Tests\Feature;
 
-use App\Models\User;
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Modules\Forum\Domain\Models\Channel;
+use Illuminate\Support\Facades\Auth;
 use Modules\Forum\Domain\Models\Reply;
 use Modules\Forum\Domain\Models\Thread;
 use Tests\TestCase;
@@ -18,18 +16,19 @@ class ParticipateInForumTest extends TestCase
     {
         $this->signIn();
         $this->assertAuthenticated('web');
-        $user = auth()->user();
 
-        $thread = create(Thread::class, ['user_id' => $user->id]);
+        $thread = create(Thread::class, ['user_id' => Auth::id()]);
 
         $reply = make(Reply::class);
 
         $this->post($thread->path() . '/replies', $reply->toArray())
-        ->assertStatus(302);
+            ->assertStatus(302);
+
+        $this->assertEquals(1, $thread->fresh()->replies_count);
 
         $this->get($thread->path())
-        ->assertSee($reply->body)
-        ->assertStatus(200);
+            ->assertSee($reply->body)
+            ->assertStatus(200);
     }
 
     public function test_unauthenticated_users_may_not_add_replies(): void
@@ -45,7 +44,7 @@ class ParticipateInForumTest extends TestCase
         $reply = make(Reply::class, ['body' => null]);
 
         $this->post($thread->path() . '/replies', $reply->toArray())
-        ->assertSessionHasErrors('body');
+            ->assertSessionHasErrors('body');
     }
 
     public function test_unauthenticated_users_may_not_delete_replies(): void
@@ -56,18 +55,19 @@ class ParticipateInForumTest extends TestCase
             ->assertRedirect('/login');
 
         $this->signIn()
-        ->delete('replies/' . $reply->id)
-        ->assertStatus(403);
+            ->delete('replies/' . $reply->id)
+            ->assertStatus(403);
     }
 
-    public function test_authorized_users_can_delete_replies():void
+    public function test_authorized_users_can_delete_replies(): void
     {
         $this->signIn();
 
-        $reply = create(Reply::class, ['user_id' => auth()->id()]);
+        $reply = create(Reply::class, ['user_id' => Auth::id()]);
         $this->delete('replies/' . $reply->id)
-        ->assertStatus(302);
+            ->assertStatus(302);
         $this->assertDatabaseMissing('replies', $reply->getAttributes());
+        $this->assertEquals(0, $reply->thread->fresh()->replies_count);
     }
 
     public function test_authorize_user_can_update_own_replies(): void
@@ -75,18 +75,18 @@ class ParticipateInForumTest extends TestCase
         $repliesOtherUser = create(Reply::class, []);
 
         $this->patch('replies/' . $repliesOtherUser->id, [])
-        ->assertRedirect('login');
+            ->assertRedirect('login');
 
         $this->signIn();
-        $replies = create(Reply::class, ['user_id' => auth()->id()]);
+        $replies = create(Reply::class, ['user_id' => Auth::id()]);
 
         $updatedReply = 'You been changed, foo.';
 
-        $this->patch('replies/' . $repliesOtherUser->id , ['body' => $updatedReply])
-        ->assertStatus(403);
+        $this->patch('replies/' . $repliesOtherUser->id, ['body' => $updatedReply])
+            ->assertStatus(403);
 
         $this->patch('replies/' . $replies->id, ['body' => $updatedReply])
-        ->assertRedirect();
+            ->assertRedirect();
 
         $this->assertDatabaseHas('replies', ['id' => $replies->id, 'body' => $updatedReply]);
     }

--- a/modules/Forum/Tests/Feature/ReadThreadTest.php
+++ b/modules/Forum/Tests/Feature/ReadThreadTest.php
@@ -8,6 +8,7 @@ use Modules\Forum\Domain\Models\Reply;
 use Modules\Forum\Domain\Models\Thread;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Auth;
 
 class ReadThreadTest extends TestCase
 {
@@ -17,6 +18,7 @@ class ReadThreadTest extends TestCase
      */
     public function test_a_user_can_view_all_threads(): void
     {
+        $this->signIn();
         $threads = create(Thread::class);
         $response = $this->get('/threads');
         $response->assertSee($threads->title);
@@ -44,21 +46,21 @@ class ReadThreadTest extends TestCase
 
     public function test_a_user_can_filter_threads_by_channel(): void
     {
+        $this->signIn();
         $channel = create(Channel::class);
         $threadInChannel = create(Thread::class, ['channel_id' => $channel->id]);
         $threadNotInChannel = create(Thread::class);
 
         $this->get('/threads/' . $channel->slug)
             ->assertSee($threadInChannel->title)
-            ->assertDontSee($threadNotInChannel->title)
-            ->assertStatus(200);
+            ->assertDontSee($threadNotInChannel->title);
     }
 
     public function test_a_user_can_filter_threads_by_any_username(): void
     {
         $this->signIn(create(User::class, ['name' => 'EslamNazer']));
 
-        $threadInChannel = create(Thread::class, ['user_id' => auth()->id()]);
+        $threadInChannel = create(Thread::class, ['user_id' => Auth::id()]);
         $threadNotInChannel = create(Thread::class);
 
         $this->get('/threads?by=EslamNazer')
@@ -80,5 +82,19 @@ class ReadThreadTest extends TestCase
         $response = $this->getJson('threads?popular')->json();
 
         $this->assertEquals([3, 2, 0], array_column($response['data'], 'replies_count'));
+    }
+
+
+    public function test_a_user_can_filter_threads_by_unanswered(): void
+    {
+        $this->signIn();
+        $this->assertAuthenticated();
+        $thread = create(Thread::class);
+        create(Reply::class, ['thread_id' => $thread->id]);
+        create(Thread::class);
+
+        $response = $this->getJson('threads?unanswered=1')->json();
+
+        $this->assertCount(1, $response['data']);
     }
 }

--- a/resources/js/components/AppSidebarHeader.vue
+++ b/resources/js/components/AppSidebarHeader.vue
@@ -17,11 +17,14 @@ withDefaults(
     <header
         class="flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/70 px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4"
     >
-        <div class="flex items-center gap-2">
+        <div class="flex w-full items-center justify-between gap-2">
             <SidebarTrigger class="-ml-1" />
             <template v-if="breadcrumbs && breadcrumbs.length > 0">
                 <Breadcrumbs :breadcrumbs="breadcrumbs" />
             </template>
+            <div class="ml-auto flex gap-3">
+                <slot name="actions" />
+            </div>
         </div>
     </header>
 </template>

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -13,6 +13,9 @@ withDefaults(defineProps<Props>(), {
 
 <template>
     <AppLayout :breadcrumbs="breadcrumbs">
+        <template #header-actions>
+            <slot name="header-actions" />
+        </template>
         <slot />
     </AppLayout>
 </template>

--- a/resources/js/layouts/app/AppSidebarLayout.vue
+++ b/resources/js/layouts/app/AppSidebarLayout.vue
@@ -18,7 +18,11 @@ withDefaults(defineProps<Props>(), {
     <AppShell variant="sidebar">
         <AppSidebar />
         <AppContent variant="sidebar" class="overflow-x-hidden">
-            <AppSidebarHeader :breadcrumbs="breadcrumbs" />
+            <AppSidebarHeader :breadcrumbs="breadcrumbs">
+                <template #actions>
+                    <slot name="header-actions" />
+                </template>
+            </AppSidebarHeader>
             <slot />
         </AppContent>
     </AppShell>

--- a/resources/js/pages/replies/Reply.vue
+++ b/resources/js/pages/replies/Reply.vue
@@ -44,6 +44,7 @@ function update() {
             },
         },
     );
+    
 }
 
 function destroy() {

--- a/resources/js/pages/threads/Index.vue
+++ b/resources/js/pages/threads/Index.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import TextLink from '@/components/TextLink.vue';
+import Button from '@/components/ui/button/Button.vue';
+import Card from '@/components/ui/card/Card.vue';
 import Select from '@/components/ui/select/Select.vue';
 import SelectContent from '@/components/ui/select/SelectContent.vue';
 import SelectItem from '@/components/ui/select/SelectItem.vue';
@@ -9,9 +11,11 @@ import AppLayout from '@/layouts/AppLayout.vue';
 import { cn } from '@/lib/utils';
 import threads from '@/routes/threads';
 import { type BreadcrumbItem } from '@/types';
+import { FireIcon } from '@heroicons/vue/20/solid';
 import { Head, router } from '@inertiajs/vue3';
 import dayjs from 'dayjs';
-import { Ref, ref } from 'vue';
+import { MessageCircleOff } from 'lucide-vue-next';
+import { markRaw, Ref, ref } from 'vue';
 import Paginator from '../accessories/paginations/Paginator.vue';
 import FavoriteButton from '../favorites/FavoriteButton.vue';
 
@@ -60,6 +64,7 @@ const props = defineProps<{
 }>();
 
 const selectChannel = ref(props.slug ?? null);
+const TextLinkRaw = markRaw(TextLink);
 
 function onChangeChannel(slug?: Ref<string | null>): void {
     if (slug) {
@@ -68,65 +73,36 @@ function onChangeChannel(slug?: Ref<string | null>): void {
         router.visit(threads.index().url);
     }
 }
-
-// const numericLinks = computed(() => {
-//     const links = props.Threads.links.filter(
-//         (link: any) => !isNaN(Number(link.label)),
-//     );
-//     const currentLink = links.find((link: any) => link.active);
-
-//     if (!currentLink) return links; // Handle case where no active link is found
-
-//     const current = Number(currentLink.label);
-//     const totalPages = links.length;
-//     const pages = [];
-
-//     // If we have 10 or fewer pages, show all pages
-//     if (totalPages <= 10) return links;
-
-//     // Always include the first page
-//     pages.push(links[0]);
-
-//     if (current <= 4) {
-//         // Show pages 1-5, then ellipsis, then last page
-//         pages.push(...links.slice(1, 5));
-//         if (totalPages > 6) {
-//             pages.push({ label: '...', url: null, active: false });
-//             pages.push(links[links.length - 1]);
-//         }
-//     } else if (current >= totalPages - 3) {
-//         // Show first page, ellipsis, then last 5 pages
-//         if (totalPages > 6) {
-//             pages.push({ label: '...', url: null, active: false });
-//         }
-//         pages.push(...links.slice(totalPages - 5, totalPages));
-//     } else {
-//         // Show first page, ellipsis, current page ±2, ellipsis, last page
-//         pages.push({ label: '...', url: null, active: false });
-//         pages.push(...links.slice(current - 3, current + 2));
-//         pages.push({ label: '...', url: null, active: false });
-//         pages.push(links[links.length - 1]);
-//     }
-
-//     // Remove duplicates that might occur at boundaries
-//     const uniquePages = [];
-//     const seenLabels = new Set();
-
-//     for (const page of pages) {
-//         if (!seenLabels.has(page.label)) {
-//             uniquePages.push(page);
-//             seenLabels.add(page.label);
-//         }
-//     }
-
-//     return uniquePages;
-// });
 </script>
 
 <template>
     <Head title="Threads" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
+        <template #header-actions>
+            <Button
+                :class="cn('!no-underline')"
+                :as="TextLinkRaw"
+                :href="'?unanswered=1'"
+            >
+                <MessageCircleOff />
+            </Button>
+            <Button
+                :class="cn('!no-underline')"
+                :as="TextLinkRaw"
+                :href="threads.index().url"
+            >
+                All Threads
+            </Button>
+            <Button
+                :class="cn('!no-underline')"
+                :as="TextLinkRaw"
+                :href="'?popular'"
+            >
+                <FireIcon class="h-5 w-5" /> Popular
+            </Button>
+        </template>
+
         <div class="mx-auto mt-4 w-full max-w-4xl">
             <div class="flex w-full justify-between">
                 <div>
@@ -166,7 +142,14 @@ function onChangeChannel(slug?: Ref<string | null>): void {
                     </Select>
                 </div>
             </div>
+            <Card
+                :class="cn('mt-4 w-full p-4 text-center text-lg')"
+                v-if="Threads.data.length === 0"
+            >
+                Threads Not Found
+            </Card>
             <div
+                v-else
                 v-for="thread in Threads.data"
                 class="my-4 w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
                 :key="thread.id"


### PR DESCRIPTION
- Make sure can filter unanswered threads (not have replies)
    - Update frontend to add button for unanswered threads
    - Update tests to cover new filter functionality
    - Fix minor issues in existing tests
    - Adding slot in AppSidebarHeader for future use
    - Fixing some issues in ReadThreadTest
- Update threads migrations to add replies_count column
    - Set default value to 0
    - Update Reply model to increment or decrement replies_count for counting replies if created or deleted
    - Update Thread model to include replies_count in fillable attributes
    - Update AllThreadsRepository to order by latest and id to avoid ambiguity