### PR TITLE
Make trending threads use Redis for caching as Infrastructure class

### DIFF
--- a/modules/Forum/Application/UseCases/Thread/ShowThreadUseCase.php
+++ b/modules/Forum/Application/UseCases/Thread/ShowThreadUseCase.php
@@ -2,15 +2,16 @@
 
 namespace Modules\Forum\Application\UseCases\Thread;
 
-use Illuminate\Support\Facades\Redis;
 use JsonException;
 use Modules\Forum\Domain\Models\Thread;
 use Modules\Forum\Domain\Repositories\Thread\FindThreadRepositoryInterface;
+use Modules\Forum\Infrastructure\Cache\Trending;
 
 class ShowThreadUseCase
 {
     public function __construct(
         protected FindThreadRepositoryInterface $findThreadRepository,
+        protected Trending $trending,
     ) {}
 
     /**
@@ -24,11 +25,7 @@ class ShowThreadUseCase
         }
         auth()->user()->read($thread);
 
-        Redis::zincrby('trending_threads', 1, json_encode([
-            'title' => $thread->title,
-            'slug' => $thread->channel->slug,
-            'path' => $thread->path()
-        ], JSON_THROW_ON_ERROR));
+        $this->trending->push($thread);
 
         return $thread;
     }

--- a/modules/Forum/Http/Controllers/ThreadController.php
+++ b/modules/Forum/Http/Controllers/ThreadController.php
@@ -3,7 +3,6 @@
 namespace Modules\Forum\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Exception;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -24,6 +23,7 @@ use Modules\Forum\Application\UseCases\Thread\StoreThreadUseCase;
 use Modules\Forum\Application\UseCases\Thread\DeleteThreadUseCase;
 use Modules\Forum\Application\UseCases\Thread\ShowThreadUseCase;
 use Modules\Forum\Http\Requests\Thread\CreateThreadRequest;
+use Modules\Forum\Infrastructure\Cache\Trending;
 
 class ThreadController extends Controller implements HasMiddleware
 {
@@ -37,7 +37,7 @@ class ThreadController extends Controller implements HasMiddleware
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request, AllThreadsUseCase $case, ?string $channel = null): View|Collection|Response|LengthAwarePaginator
+    public function index(Request $request, AllThreadsUseCase $case,  Trending $trending,?string $channel = null): View|Collection|Response|LengthAwarePaginator
     {
         $dto = new AllThreadsFilteredDto(channel: $channel);
         $threads = $case->execute($request, $dto);
@@ -51,8 +51,6 @@ class ThreadController extends Controller implements HasMiddleware
             return $thread;
         });
 
-        $trending = array_map('json_decode', Redis::zrevrange('trending_threads', 0, 4));
-
         if ($request->wantsJson()) {
             return $threads;
         }
@@ -60,7 +58,7 @@ class ThreadController extends Controller implements HasMiddleware
         return Inertia::render('threads/Index', [
             'Threads' => $threads,
             'slug' => $channel,
-            'trending' => $trending,
+            'trending' => $trending->get(),
         ]);
     }
 

--- a/modules/Forum/Infrastructure/Cache/Trending.php
+++ b/modules/Forum/Infrastructure/Cache/Trending.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Modules\Forum\Infrastructure\Cache;
+
+use Illuminate\Support\Facades\Redis;
+use JsonException;
+use Modules\Forum\Domain\Models\Thread;
+
+class Trending
+{
+    /**
+     * @return array
+     */
+    public function get(): array
+    {
+        return array_map('json_decode', Redis::zrevrange($this->cacheKey(), 0, 4));
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function push(Thread $thread): void
+    {
+        Redis::zincrby($this->cacheKey(), 1, json_encode([
+            'title' => $thread->title,
+            'slug'  => $thread->channel->slug,
+            'path'  => $thread->path()
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function cacheKey(): string
+    {
+        return app()->environment('testing') ? 'testing_trending_threads' : 'trending_threads';
+    }
+
+    public function reset(): void
+    {
+        Redis::del($this->cacheKey());
+    }
+}

--- a/modules/Forum/Tests/Feature/TrendingThreadTest.php
+++ b/modules/Forum/Tests/Feature/TrendingThreadTest.php
@@ -5,6 +5,7 @@ namespace Modules\Forum\Tests\Feature;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Facades\Redis;
 use Modules\Forum\Domain\Models\Thread;
+use Modules\Forum\Infrastructure\Cache\Trending;
 use Tests\TestCase;
 
 class TrendingThreadTest extends TestCase
@@ -15,24 +16,21 @@ class TrendingThreadTest extends TestCase
     {
         parent::setUp();
 
-        Redis::del('trending_threads');
+        $this->trending = new Trending();
+        $this->trending->reset();
     }
 
     public function test_increment_a_thread_score_each_time_it_is_read(): void
     {
         $this->signIn();
-        $this->assertEmpty(Redis::zrange('trending_threads', 0, -1));
+        $this->assertEmpty($this->trending->get());
 
         $thread = create(Thread::class);
 
         $this->call('GET', $thread->path());
 
-        $trending = Redis::zrange('trending_threads', 0, -1);
+        $this->assertCount(1, $trending = $this->trending->get());
 
-        $this->assertCount(1, $trending);
-
-        $this->assertEquals($thread->title, json_decode($trending[0])->title);
-
-        Redis::del('trending_threads');
+        $this->assertEquals($thread->title, $trending[0]->title);
     }
 }


### PR DESCRIPTION
    - Add Trending Infrastructure class for Redis caching of trending threads
    - Refactor ShowThreadUseCase to use the new Trending cache class
    - Update ThreadController to utilize the Trending cache class
    - Modify TrendingThreadTest to accommodate changes in caching mechanism