### PR TITLE
Make sure slugs are generated and used in forum threads

### DIFF
--- a/modules/Forum/Database/Factories/ThreadFactory.php
+++ b/modules/Forum/Database/Factories/ThreadFactory.php
@@ -19,12 +19,10 @@ class ThreadFactory extends Factory
      */
     public function definition(): array
     {
-        $title = fake()->sentence();
         return [
             'user_id' => fn () => User::factory()->create()->id,
             'channel_id' => fn () => Channel::factory()->create()->id,
-            'title' => $title,
-            'slug' => $title,
+            'title' => fake()->sentence(),
             'body' => fake()->paragraph(),
         ];
     }

--- a/modules/Forum/Database/migrations/2025_12_13_200621_add_slug_column_to_threads_table.php
+++ b/modules/Forum/Database/migrations/2025_12_13_200621_add_slug_column_to_threads_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('threads', function (Blueprint $table) {
-            $table->string('slug')->after('title')->unique();
+            $table->string('slug')->after('title')->unique()->nullable();
         });
     }
 

--- a/modules/Forum/Domain/Models/Thread.php
+++ b/modules/Forum/Domain/Models/Thread.php
@@ -47,6 +47,10 @@ class Thread extends Model
                 $reply->delete();
             });
         });
+
+        static::created(static function (self $thread): void {
+            $thread->update(['slug' => Str::slug($thread->title)]);
+        });
     }
 
     /**
@@ -223,29 +227,18 @@ class Thread extends Model
 
     public function visitsCount(): Attribute
     {
-        return Attribute::get(fn (): int => $this->visits()->count());
+        return Attribute::get(fn(): int => $this->visits()->count());
     }
 
     protected function slug(): Attribute
     {
         return Attribute::make(set: function ($value) {
-            if(static::query()->whereSlug($slug = Str::slug($value))->exists()) {
-                $slug = $this->incrementSlug($slug);
+            $slug = Str::slug($value);
+
+            if (static::query()->whereSlug($slug)->exists()) {
+                $slug = "{$slug}-" . $this->id;
             }
             return $slug;
         });
-    }
-
-    public function incrementSlug(string $slug): string
-    {
-        $max = static::query()->whereTitle($this->title)->latest('id')->value('slug');
-
-        if (is_numeric($max[-1])) {
-            return preg_replace_callback('/(\d+)$/', function ($match) {
-                return $match[1] + 1;
-            }, $max);
-        }
-
-        return "{$slug}-2";
     }
 }

--- a/modules/Forum/Http/Controllers/ThreadController.php
+++ b/modules/Forum/Http/Controllers/ThreadController.php
@@ -23,6 +23,7 @@ use Modules\Forum\Application\UseCases\Thread\DeleteThreadUseCase;
 use Modules\Forum\Application\UseCases\Thread\ShowThreadUseCase;
 use Modules\Forum\Http\Requests\Thread\CreateThreadRequest;
 use Modules\Forum\Infrastructure\Cache\Trending;
+use Illuminate\Http\Response as HttpResponse;
 
 class ThreadController extends Controller implements HasMiddleware
 {
@@ -64,7 +65,7 @@ class ThreadController extends Controller implements HasMiddleware
     /**
      * Store a newly created resource in storage.
      */
-    public function store(CreateThreadRequest $request, StoreThreadUseCase $case): RedirectResponse
+    public function store(CreateThreadRequest $request, StoreThreadUseCase $case): RedirectResponse|HttpResponse
     {
         $data = new CreateThreadDto(
             userId: Auth::id(),
@@ -72,7 +73,12 @@ class ThreadController extends Controller implements HasMiddleware
             title: $request->validated('title'),
             body: $request->validated('body')
         );
-        $case->execute($data);
+        $thread = $case->execute($data);
+
+        if (request()->wantsJson()) {
+            return response($thread, 201);
+        }
+
         return redirect()->route('threads.index');
     }
 

--- a/modules/Forum/Tests/Feature/CreateThreadTest.php
+++ b/modules/Forum/Tests/Feature/CreateThreadTest.php
@@ -114,17 +114,32 @@ class CreateThreadTest extends TestCase
     {
         $this->signIn()->withoutExceptionHandling();
 
-        $thread = create(Thread::class, ['title' => 'Foo title', 'slug' => 'foo-title']);
+        $thread = create(Thread::class, ['title' => 'Foo title']);
 
         $this->assertEquals('foo-title', $thread->fresh()->slug);
 
+        $response = $this->postJson(route('threads.store'), $thread->toArray());
+
+        $this->assertEquals('foo-title-2', $response->json('slug'));
+
+        $response = $this->postJson(route('threads.store'), $thread->toArray());
+
+        $this->assertEquals('foo-title-3', $response->json('slug'));
+    }
+
+    public function test_a_thread_with_a_title_thad_ends_in_a_number_should_generate_the_proper_slug(): void
+    {
+        $this->signIn()->withoutExceptionHandling();
+
+        $thread = create(Thread::class, ['title' => 'Some Title 24']);
+
         $this->post(route('threads.store'), $thread->toArray());
 
-        $this->assertTrue(Thread::query()->where('slug', 'foo-title-2')->exists());
+        $this->assertTrue(Thread::query()->where('slug', 'some-title-24-2')->exists());
 
         $this->post(route('threads.store'), $thread->toArray());
 
-        $this->assertTrue(Thread::query()->where('slug', 'foo-title-3')->exists());
+        $this->assertTrue(Thread::query()->where('slug', 'some-title-24-3')->exists());
     }
 
     public function test_guests_cannot_remove_threads(): void

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,9 +22,9 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-<!--        <env name="DB_DATABASE" value="testing"/>-->
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_DATABASE" value="testing"/>
+<!--        <env name="DB_CONNECTION" value="sqlite"/>-->
+<!--        <env name="DB_DATABASE" value=":memory:"/>-->
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
    - Make sure slugs are created when a thread is created
    - Update thread URLs to use slugs instead of IDs
    - Update tests to reflect slug usage in threads
    - Modify database migration to add slug column to threads table